### PR TITLE
Remove trailing 'null' when no meta exist

### DIFF
--- a/lib/winston-syslog-ain2.js
+++ b/lib/winston-syslog-ain2.js
@@ -19,6 +19,6 @@ util.inherits(SyslogAin2, winston.Transport);
 SyslogAin2.prototype.name = 'SyslogAin2';
 
 SyslogAin2.prototype.log = function (level, msg, meta, callback) {
-  ain[level](msg + util.inspect(meta));
+  ain[level](msg + (null!=meta ? ' '+util.inspect(meta) : ''));
   callback();
 };


### PR DESCRIPTION
I found that all my logs with any meta appear in syslog with a trailing null, so I removed it.
