### PR TITLE
Fix bug that the old settings of the ain2 is got replaced

### DIFF
--- a/lib/winston-syslog-ain2.js
+++ b/lib/winston-syslog-ain2.js
@@ -6,12 +6,10 @@ var util = require('util'),
     winston = require('winston'),
     SysLogger = require("ain2");
 
-var ain;
-
 var SyslogAin2 = exports.SyslogAin2 = function (options) {
   winston.Transport.call(this, options);
   options = options || {};
-  ain = new SysLogger(options);
+  this.ain = new SysLogger(options);
 };
 
 util.inherits(SyslogAin2, winston.Transport);
@@ -19,6 +17,6 @@ util.inherits(SyslogAin2, winston.Transport);
 SyslogAin2.prototype.name = 'SyslogAin2';
 
 SyslogAin2.prototype.log = function (level, msg, meta, callback) {
-  ain[level](msg + (null!=meta ? ' '+util.inspect(meta) : ''));
+  this.ain[level](msg + (null!=meta ? ' '+util.inspect(meta) : ''));
   callback();
 };


### PR DESCRIPTION
Hi. lamtha

I found the ain object is accidentally got replaced when I made another SyslogAin2 object.
The bug was fixed. Could you merge my bugifix?
Thanks.

Kohei
